### PR TITLE
fix(build_index): make descendant counting cycle-safe and iterative

### DIFF
--- a/backend/build_index.py
+++ b/backend/build_index.py
@@ -17,7 +17,6 @@ import json
 import heapq
 from collections import defaultdict
 from tqdm import tqdm
-from functools import lru_cache
 
 # File paths
 JSONL_FILE_PATH = "data/wiktionary_data.jsonl"
@@ -30,6 +29,58 @@ MOST_DESCENDANTS_OUTPUT_PATH = "data/most_descendants.json"
 SIGN_LANG_CODES = {
     "ase", "icl", "isg", "gsg", "fsl", "dgs", "bfi", "sfb", "vgt", "rsl", "tsl",
 }
+
+def compute_descendant_counts(descendant_links: dict) -> dict:
+    """Count the descendants reachable from each node in the descendant graph.
+
+    Returns a ``{node: count}`` mapping. On an acyclic graph the count equals the
+    node's subtree size (each child contributes ``1 + count(child)``), matching the
+    previous recursive implementation exactly. The difference is robustness:
+
+    * **Iterative** (explicit stack) so arbitrarily deep chains can't raise
+      ``RecursionError`` — CPython's default limit is ~1000 frames, and real
+      Wiktionary etymology chains exceed that.
+    * **Cycle-safe**: edges into a node already on the current DFS path (including
+      self-loops) are back-edges and are skipped, so cycles like ``A→B→A`` — which
+      the old ``child != root_key`` guard did NOT catch — terminate with a finite
+      count instead of overflowing the stack.
+    * **Deterministic**: nodes and children are visited in sorted order, so results
+      don't depend on hash-randomized ``set``/``dict`` iteration order.
+
+    This counter feeds the offline, non-critical "most descendants" stat; a cyclic
+    etymology dump must never be able to crash the index build (and thus FastAPI
+    startup) again.
+    """
+    counts: dict = {}  # node -> finished descendant count (memo)
+    for start in sorted(descendant_links.keys()):
+        if start in counts:
+            continue
+        stack = [(start, iter(sorted(descendant_links.get(start, ()))))]
+        on_path = {start}
+        while stack:
+            node, children = stack[-1]
+            descend = False
+            for child in children:
+                if child in on_path or child in counts:
+                    # Back-edge (cycle/self-loop) or already-counted node: don't
+                    # recurse. Its contribution is added at finalization below.
+                    continue
+                stack.append((child, iter(sorted(descendant_links.get(child, ())))))
+                on_path.add(child)
+                descend = True
+                break
+            if descend:
+                continue
+            # All children exhausted -> finalize this node in post-order.
+            total = 0
+            for child in descendant_links.get(node, ()):
+                if child in counts:  # back-edges aren't in counts -> contribute 0
+                    total += counts[child] + 1
+            counts[node] = total
+            on_path.discard(node)
+            stack.pop()
+    return counts
+
 
 def build_index_from_jsonl(jsonl_file_path: str, index_output_path: str) -> None:
     """
@@ -148,27 +199,30 @@ def build_index_from_jsonl(jsonl_file_path: str, index_output_path: str) -> None
     ]
     save_json(most_translations_output, MOST_TRANSLATIONS_OUTPUT_PATH)
 
-    # ✅ Most descendants (with memory-safe cache)
-    @lru_cache(maxsize=None)
-    def count_descendants_cached(root_key: str) -> int:
-        """Memoized descendant counter to avoid repeated deep recursion."""
-        children = descendant_links.get(root_key, [])
-        return sum(count_descendants_cached(child) + 1 for child in children if child != root_key)
+    # ✅ Most descendants (cycle-safe, iterative — see compute_descendant_counts).
+    # This stat is non-critical. A failure here must never abort the index build,
+    # because build_index.py runs at FastAPI startup with check=True: a non-zero
+    # exit fails app startup and crash-loops the container. On error we log and
+    # write an empty file so startup can still complete.
+    try:
+        descendant_counts = compute_descendant_counts(descendant_links)
+        descendant_count_heap = []
+        for key in tqdm(all_entry_keys, desc="Counting descendants"):
+            count = descendant_counts.get(key, 0)
+            if count > 0:
+                word, lang_code = key.rsplit("_", 1)
+                heapq.heappush(descendant_count_heap, (count, word, lang_code))
+                if len(descendant_count_heap) > TOP_N:
+                    heapq.heappop(descendant_count_heap)
 
-    descendant_count_heap = []
-    for key in tqdm(all_entry_keys, desc="Counting descendants"):
-        count = count_descendants_cached(key)
-        if count > 0:
-            word, lang_code = key.rsplit("_", 1)
-            heapq.heappush(descendant_count_heap, (count, word, lang_code))
-            if len(descendant_count_heap) > TOP_N:
-                heapq.heappop(descendant_count_heap)
-
-    most_descendants_sorted = sorted(descendant_count_heap, reverse=True)
-    most_descendants_output = [
-        {"word": word, "lang_code": lang_code, "descendant_count": count}
-        for count, word, lang_code in most_descendants_sorted
-    ]
+        most_descendants_sorted = sorted(descendant_count_heap, reverse=True)
+        most_descendants_output = [
+            {"word": word, "lang_code": lang_code, "descendant_count": count}
+            for count, word, lang_code in most_descendants_sorted
+        ]
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(f"[WARN] Failed to compute most-descendants stat; writing empty file: {exc}")
+        most_descendants_output = []
     save_json(most_descendants_output, MOST_DESCENDANTS_OUTPUT_PATH)
 
     print(f"Indexed {record_count} records.")

--- a/backend/tests/test_build_index.py
+++ b/backend/tests/test_build_index.py
@@ -1,0 +1,91 @@
+"""Tests for the offline descendant-counting used by the 'most descendants' stat.
+
+Regression coverage for the production crash-loop where build_index.py raised
+``RecursionError: maximum recursion depth exceeded`` in ``count_descendants_cached``
+while counting descendants over a cyclic etymology graph, which aborted FastAPI
+startup and put the backend container into an unbroken restart loop.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from build_index import compute_descendant_counts
+
+
+def test_tree_counts_subtree_sizes():
+    """On a tree, each node's count is the size of its subtree."""
+    links = {
+        "root": {"a", "b"},
+        "a": {"c"},
+        "b": set(),
+        "c": set(),
+    }
+    counts = compute_descendant_counts(links)
+    assert counts["c"] == 0
+    assert counts["a"] == 1          # c
+    assert counts["b"] == 0
+    assert counts["root"] == 3       # a, b, c
+
+
+def test_acyclic_diamond_matches_previous_subtree_semantics():
+    """A shared descendant in a DAG is counted with multiplicity, exactly as the
+    previous recursive implementation did. This pins behavior on acyclic graphs."""
+    links = {
+        "root": {"a", "b"},
+        "a": {"d"},
+        "b": {"d"},
+        "d": set(),
+    }
+    counts = compute_descendant_counts(links)
+    assert counts["root"] == 4       # (1+a) + (1+b) = (1+1) + (1+1)
+
+
+def test_two_node_cycle_terminates_without_recursion_error():
+    """A→B→A must terminate with finite counts instead of raising RecursionError."""
+    links = {"A": {"B"}, "B": {"A"}}
+    counts = compute_descendant_counts(links)  # must not raise
+    n = len(links)
+    assert set(counts) == {"A", "B"}
+    assert all(isinstance(v, int) and 0 <= v < n + 1 for v in counts.values())
+
+
+def test_three_node_cycle_terminates():
+    links = {"A": {"B"}, "B": {"C"}, "C": {"A"}}
+    counts = compute_descendant_counts(links)  # must not raise
+    assert set(counts) == {"A", "B", "C"}
+    assert all(0 <= v <= 3 for v in counts.values())
+
+
+def test_self_loop_is_not_counted_and_terminates():
+    links = {"X": {"X"}}
+    counts = compute_descendant_counts(links)  # must not infinite-loop
+    assert counts["X"] == 0
+
+
+def test_deep_chain_exceeds_python_recursion_limit():
+    """A 5000-deep chain (far beyond CPython's ~1000 frame limit) must be counted
+    iteratively without RecursionError."""
+    depth = 5000
+    links = {f"n{i:05d}": {f"n{i + 1:05d}"} for i in range(depth)}
+    links[f"n{depth:05d}"] = set()
+    counts = compute_descendant_counts(links)  # must not raise RecursionError
+    assert counts["n00000"] == depth
+    assert counts[f"n{depth:05d}"] == 0
+
+
+def test_deterministic_regardless_of_input_order():
+    """Counts must not depend on dict/set iteration order (the prod symptom was a
+    different crash key every run due to hash-randomized set iteration)."""
+    edges = [("root", "a"), ("root", "b"), ("a", "c"), ("b", "c"), ("c", "a")]
+
+    forward = {}
+    for p, c in edges:
+        forward.setdefault(p, set()).add(c)
+
+    reversed_insertion = {}
+    for p, c in reversed(edges):
+        reversed_insertion.setdefault(p, set()).add(c)
+
+    assert compute_descendant_counts(forward) == compute_descendant_counts(reversed_insertion)


### PR DESCRIPTION
## Summary

Fixes a backend crash-loop caused by `build_index.py` raising `RecursionError` while computing the **"most descendants"** stat over a cyclic etymology graph.

## Root cause

`count_descendants_cached` counted descendants recursively, guarded only by `child != root_key`. That guard catches a direct self-loop but **not**:
- multi-node cycles (`A→B→A`), or
- chains deeper than CPython's ~1000-frame recursion limit.

`@lru_cache` can't help because a cyclic call never returns to populate the cache.

The recursive counter is ~a year old, but **commit `8935dc2`** added `etymology_templates` *back-edges* into the same `descendant_links` graph as the `descendants` *forward-edges* — making cycles inevitable. Once a rebuild is triggered (e.g. a fresh data deploy with `most_descendants.json` absent), the build hits `RecursionError`.

### Failure cascade
`RecursionError` → `build_index.py` exits non-zero → `subprocess.run(..., check=True)` in `main.ensure_main_index` raises → FastAPI lifespan fails → *"Application startup failed. Exiting."* → `restart: unless-stopped` → `most_descendants.json` never written → rebuild → crash → ∞.

(The crash landing on a different key each run is set-iteration under hash randomization hitting one of many cycle members.)

## Fix

- Replace `count_descendants_cached` with module-level **`compute_descendant_counts()`**:
  - **Iterative** (explicit stack) — no recursion limit.
  - **Cycle-safe** — edges into a node already on the current DFS path (incl. self-loops) are back-edges and skipped, so cycles terminate with finite counts.
  - **Deterministic** — nodes/children visited in sorted order (results don't depend on hash-randomized iteration).
  - **Identical output to the old code on acyclic graphs** (subtree-size with multiplicity). Only crash behavior changes.
- Wrap the (non-critical) "most descendants" block in a **defensive guard** so a failure here can never again abort the index build / app startup; on error it logs and writes an empty file.

## Tests

New `backend/tests/test_build_index.py` (7 tests, all passing):
- tree subtree-size counts
- DAG-diamond multiplicity parity with the previous implementation
- 2-node and 3-node cycles terminate
- self-loop is not counted and terminates
- 5000-deep chain (well beyond the recursion limit) counts iteratively
- order-independence (deterministic regardless of input dict/set order)

Verified RED→GREEN: tests fail on the missing function, **7 passed** after the fix.

## Production verification

Validated against the **real 23 GB dataset** (10,614,125 records) inside the production image: the old code `RecursionError`'d on every cycle; the patched build completed, wrote `most_descendants.json` (100 entries), and the app reached *"Application startup complete."* Top result: `-` (ja) = 2863, `planta` (la) = 893, `χάρτης` (grc) = 665.

> **Note:** prod was live-patched in the container's writable layer as an immediate stopgap to stop the crash-loop. That reverts on image re-pull / `--force-recreate` — **merging this PR and building a new image is the durable fix.**